### PR TITLE
feat: Make bullet bigger and auto-release ball

### DIFF
--- a/sprites.py
+++ b/sprites.py
@@ -1,4 +1,4 @@
-import pygame
+import pygame, time
 from settings import *
 from random import choice
 
@@ -76,6 +76,7 @@ class Ball(pygame.sprite.Sprite):
 
         # active
         self.active = False
+        self.creation_time = time.time()
 
 
 
@@ -102,6 +103,7 @@ class Ball(pygame.sprite.Sprite):
 
             if self.rect.bottom > WINDOW_HEIGHT:
                 self.active = False
+                self.creation_time = time.time()
                 self.direction.y = -1
                 self.game.lose_life()
                 self.kill()
@@ -173,11 +175,14 @@ class Ball(pygame.sprite.Sprite):
             self.rect.midbottom = self.player.rect.midtop
             self.pos = pygame.math.Vector2(self.rect.topleft)
 
+            if time.time() - self.creation_time >= 5:
+                self.active = True
+
 class Bullet(pygame.sprite.Sprite):
     def __init__(self, pos, groups):
         super().__init__(groups)
         self.image = pygame.image.load('bullet.png').convert_alpha()
-        self.image = pygame.transform.scale(self.image, (10, 10))
+        self.image = pygame.transform.scale(self.image, (20, 20))
         self.rect = self.image.get_rect(midbottom=pos)
         self.speed = 600
 


### PR DESCRIPTION
This commit addresses two requested features:

1.  **Bigger Bullet:** The `bullet.png` graphic has been scaled to be larger, improving its visibility. The size was changed from (10, 10) to (20, 20) in `sprites.py`.

2.  **Automatic Ball Release:** The ball now automatically releases from the paddle after 5 seconds of being in a "sitting" state. This is implemented by adding a timer to the `Ball` class in `sprites.py`.